### PR TITLE
Feature/rnf02. control y privacidad

### DIFF
--- a/docs/02_requirements/rnf02_requirement_description.md
+++ b/docs/02_requirements/rnf02_requirement_description.md
@@ -1,0 +1,81 @@
+# RNF-02. Control de acceso básico y privacidad en UI
+
+## Descripción
+El sistema deberá implementar un mecanismo de acceso básico en la interfaz que permita identificar al usuario mediante correo o nombre de usuario y contraseña.
+
+Cada usuario tendrá un rol predefinido (secretaria o coordinador), el cual determinará las vistas, módulos y acciones que podrá visualizar y ejecutar dentro del sistema.
+
+El sistema deberá restringir el acceso a las pantallas principales si el usuario no ha iniciado sesión y permitir el cierre de sesión regresando a la pantalla de acceso.
+
+Asimismo, la interfaz deberá evitar mostrar información sensible innecesaria de los pacientes en búsquedas, listados, mensajes y rutas visibles, limitando los datos únicamente a los necesarios para la operación.
+
+El alcance de este requisito se limita al control de acceso en frontend, sin contemplar autenticación robusta en backend.
+
+---
+
+## Categoría
+Seguridad (control de acceso) y privacidad de datos
+
+---
+
+## Objetivo del requisito
+Implementar control de acceso básico basado en roles y reducir la exposición de información sensible en la interfaz del sistema.
+
+---
+
+## Escenario de calidad
+
+**Contexto:**  
+Usuario accede al sistema web de la clínica  
+
+**Estímulo:**  
+El usuario intenta iniciar sesión o acceder a una vista del sistema  
+
+**Respuesta esperada:**  
+- Si las credenciales son correctas, el sistema permite el acceso  
+- El sistema muestra únicamente las vistas y acciones correspondientes al rol del usuario  
+- Si no hay sesión activa, el acceso a las pantallas principales es bloqueado  
+- La interfaz muestra únicamente información necesaria, evitando datos sensibles innecesarios  
+
+---
+
+## Criterios de aceptación
+
+- El sistema solicita usuario o correo y contraseña para ingresar  
+- Cada cuenta tiene un rol predefinido: secretaria o coordinador  
+- Al iniciar sesión, el sistema muestra solo los módulos, vistas y acciones permitidas para ese rol  
+- Sin iniciar sesión no se puede acceder a las pantallas principales del sistema  
+- Existe opción de cerrar sesión  
+- Al cerrar sesión, el sistema regresa a la pantalla de acceso  
+- La interfaz evita mostrar información sensible innecesaria en búsquedas, listados y mensajes  
+- No se exponen datos sensibles en rutas visibles (URL)  
+- El control de acceso se limita a frontend (no incluye seguridad backend)  
+
+---
+
+## Verificación
+
+El cumplimiento del requisito se verificará mediante:
+
+- Pruebas de inicio de sesión con credenciales válidas e inválidas  
+- Intentos de acceso a rutas protegidas sin autenticación  
+- Validación de visibilidad de módulos según el rol del usuario  
+- Revisión de datos mostrados en listados y búsquedas  
+- Pruebas de cierre de sesión y redirección al login  
+
+---
+
+## Consistencia
+
+Este requisito es consistente con los requisitos funcionales de gestión de citas (creación, consulta, modificación y cancelación), así como con los requisitos no funcionales de integridad de datos y minimización de exposición de información.
+
+No presenta contradicciones con otros requisitos del sistema.
+
+---
+
+## Métricas de cumplimiento
+
+- El 100% de las rutas protegidas requieren sesión activa  
+- El 100% de los usuarios visualizan únicamente módulos permitidos por su rol  
+- No se muestra información sensible innecesaria en listados y búsquedas  
+- El sistema redirige correctamente al login al cerrar sesión  


### PR DESCRIPTION
Descripción
Se realizó la documentación del requisito no funcional RNF-02 – Control y privacidad de la información, así como su representación en el diseño del sistema.
Este requisito establece que el sistema debe limitar el acceso y la visualización de los datos sensibles de los pacientes únicamente al personal autorizado, garantizando la confidencialidad de la información.
Se integra con los flujos existentes de registro, consulta y visualización de citas, asegurando que la información mostrada sea la mínima necesaria en cada proceso.

Puntos clave integrados en la entrega

Definición de restricciones de acceso a la información según el rol del usuario.
Aplicación de la minimización de datos en las pantallas del sistema.
Protección de la información sensible durante la visualización y gestión de citas.
Integración del requisito con los procesos actuales sin afectar la funcionalidad del sistema.

Relacionados:

RF-01. Registrar cita
RF-02. Mostrar resumen final de la cita antes de confirmar
RF-05. Visualizar citas en calendario
Closes #13 

Tipo de cambio

☑️Nueva funcionalidad
☑️Corrección de error
☑️Otro (Requisito no funcional – Seguridad y privacidad)